### PR TITLE
Consistent type of contentSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ classDiagram
   class response {
     status: string
     contentType: string
-    contentSchema: string
+    contentSchema: JSONSchema
   }  
 
 


### PR DESCRIPTION
Use `contentSchema: JSONSchema` consistently in diagram

@darrelmiller 